### PR TITLE
Fix Critical Error after checkout

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -74,8 +74,10 @@ function famcare_rest_prepare_shop_order_object( WP_REST_Response $response ){
 	$_qr_code_image_url = famcare_get_zatca_qr_code($response->data['id']);
 	if($_qr_code_image_url){
 		$response->data['qr_code'] = $_qr_code_image_url;
+		return $response;
 	} else
 		$response->data['qr_code'] = wc_placeholder_img_src();
+		return $response;
 }
 add_filter( 'woocommerce_rest_prepare_shop_order_object', 'famcare_rest_prepare_shop_order_object', 10, 1 );
 


### PR DESCRIPTION
After processing an Order, we are getting critical errors on the website and through multiple php errors, pointing that the response is null and some fields are not available in the `data`.

After tracing this issue, we found out that it was because the function `famcare_rest_prepare_shop_order_object` wasn't returning the `response` properly.

This function should return `$response` in order for WooCommerce to proceed correctly.


This has been tested on our website and it works after investigating each plugin of ours, and the errors are no longer showing after this patch.

Looking for your feedback and review on this patch.